### PR TITLE
Fix information about Helios DAC in unit conversion

### DIFF
--- a/packages/helios/src/convert.ts
+++ b/packages/helios/src/convert.ts
@@ -1,5 +1,5 @@
-// The Ether Dream firmware uses 16-bit integers for the resolution, ranging from 0 to 65535.
-// Source: https://github.com/j4cbo/j4cDAC/blob/e592ebcb7c9b6fb521be2005f4b85de54bc04f0f/common/protocol.h
+// The Helios DAC firmware uses 12-bit integers for the resolution, ranging from 0 to 4096.
+// Source: https://github.com/Grix/helios_dac/blob/master/sdk/HeliosDac.h
 export const XY_RESOLUTION = 4096;
 export const COLOR_RESOLUTION = 255;
 


### PR DESCRIPTION
Hey, it is realy a nitpit issue but the Helios DAC script contains the info from the Ether Dream. 