### PR TITLE
Allow color override for Ilda and IldaFont

### DIFF
--- a/packages/draw/src/Ilda.ts
+++ b/packages/draw/src/Ilda.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { fromByteArray, Section } from '@laser-dac/ilda-reader';
 import { Shape } from './Shape';
+import { Color } from './Point';
 
 export interface File {
   sections: Section[];
@@ -10,6 +11,7 @@ interface IldaOptions {
   x?: number;
   y?: number;
   size?: number;
+  color?: Color;
   frame: number;
   file: File;
 }
@@ -18,6 +20,7 @@ export class Ilda extends Shape {
   x?: number;
   y?: number;
   size?: number;
+  color?: Color;
   frame: number;
   file: File;
 
@@ -26,13 +29,17 @@ export class Ilda extends Shape {
     this.x = options.x;
     this.y = options.y;
     this.size = options.size;
+    this.color = options.color;
     this.frame = options.frame;
     this.file = options.file;
   }
 
   isStatic() {
     return (
-      this.x === undefined && this.y === undefined && this.size === undefined
+      this.x === undefined &&
+      this.y === undefined &&
+      this.size === undefined &&
+      this.color === undefined
     );
   }
 
@@ -44,14 +51,17 @@ export class Ilda extends Shape {
     }
     const x = this.x || 0;
     const y = this.y || 0;
+    const color = this.color;
     const size = this.size || 1;
+
     return section.points.map(point => {
+      const isBlank = point.r === 0 && point.g === 0 && point.b === 0;
       return {
         x: x + point.x * size,
         y: y + point.y * size,
-        r: point.r,
-        g: point.g,
-        b: point.b
+        r: color !== undefined && !isBlank ? color[0] : point.r,
+        g: color !== undefined && !isBlank ? color[1] : point.g,
+        b: color !== undefined && !isBlank ? color[2] : point.b
       };
     });
   }

--- a/packages/draw/src/IldaFont.ts
+++ b/packages/draw/src/IldaFont.ts
@@ -1,7 +1,7 @@
 import { Shape } from './Shape';
 import { Ilda, File } from './Ilda';
 import { flatten } from './helpers';
-import { Point } from './Point';
+import { Color, Point } from './Point';
 
 type FontMapping = { [index: string]: number };
 
@@ -10,6 +10,7 @@ interface IldaFontOptions {
   x?: number;
   y?: number;
   size?: number;
+  color?: Color;
   fontWidth?: number;
   file: File;
   mapping: FontMapping;
@@ -22,6 +23,7 @@ export class IldaFont extends Shape {
   x: number;
   y: number;
   size: number;
+  color?: Color;
   file: File;
   fontWidth: number;
   mapping: FontMapping;
@@ -31,6 +33,7 @@ export class IldaFont extends Shape {
     this.x = options.x || 0;
     this.y = options.y || 0;
     this.size = options.size || 1;
+    this.color = options.color;
     this.text = options.text;
     this.file = options.file;
     this.mapping = options.mapping;
@@ -47,7 +50,8 @@ export class IldaFont extends Shape {
         frame,
         y: this.y,
         size: this.size,
-        x: this.x + i * fontWidth
+        x: this.x + i * fontWidth,
+        color: this.color
       }).draw();
     });
     return flatten(chars) as Point[];


### PR DESCRIPTION
Allow overriding the color specificied in the Ilda file. The primary use-case for this is the IldaFont functionality. By allowing you to pass a color you can dynamicly color the text