### PR TITLE
Add bound and compositor transformers

### DIFF
--- a/packages/draw/src/index.ts
+++ b/packages/draw/src/index.ts
@@ -7,4 +7,6 @@ export { IldaFont } from './IldaFont';
 export { Timeline } from './Timeline';
 export { rotate } from './transformers/rotate';
 export { distort } from './transformers/distort';
+export { bound } from './transformers/bound';
+export { compositor } from './transformers/compositor';
 export { Svg, loadSvgFile } from './Svg';

--- a/packages/draw/src/transformers/bound.ts
+++ b/packages/draw/src/transformers/bound.ts
@@ -1,0 +1,42 @@
+import { Point } from '../Point';
+
+interface BoundTransformerOptions {
+  lowestX?: number;
+  lowestY?: number;
+  highestX?: number;
+  highestY?: number;
+}
+
+function boundValue(min: number, max: number, value: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+// Bound values to a specific X-Y range. Can be used for safe zones e.g.
+export function bound(options: BoundTransformerOptions) {
+  const lowestX: number = options.lowestX || 0.0;
+  const lowestY: number = options.lowestY || 0.0;
+  const highestX: number = options.highestX || 1.0;
+  const highestY: number = options.highestY || 1.0;
+
+  return function(points: Point[]) {
+    return points.map(function(point: Point): Point {
+      if (
+        point.x > lowestX &&
+        point.x < highestX &&
+        point.y > lowestY &&
+        point.y < highestY
+      ) {
+        return point;
+      }
+
+      // Replace out of bound points with blanking points at the edge position.
+      // TODO: Very crude algorithm. Can cause some position/color issues when
+      //       used at low resolutions.
+      return new Point(
+        boundValue(lowestX, highestX, point.x),
+        boundValue(lowestY, highestY, point.y),
+        [0, 0, 0]
+      );
+    });
+  };
+}

--- a/packages/draw/src/transformers/compositor.ts
+++ b/packages/draw/src/transformers/compositor.ts
@@ -1,0 +1,16 @@
+import { Point } from '../Point';
+
+type TransformFn = (points: Point[]) => Point[];
+
+// Compositor allows combining multiple transformers
+export function compositor(transformers: TransformFn[]): TransformFn {
+  return function(points: Point[]): Point[] {
+    let transformedPoints: Point[] = points;
+
+    transformers.forEach(function(transformer) {
+      transformedPoints = transformer(transformedPoints);
+    });
+
+    return transformedPoints;
+  };
+}


### PR DESCRIPTION
**compositor** transformer allows compositing multiple transformers and the
**bound** transformer makes sure all emitted points are within the bounding region. 

----

The rationale of the bound transformer is that I ran into an issue where points where outside the bounds of 0.0 - 1.0 causing the Helios DAC driver to crash. This is already fixed in the application itself but I tried to make a more generic solution. 

Combined with perspective transform it can be a little unpredictable where points will end up. It can also be usefull when a safe zone is desired. 

The algorithm is currently a little bit crude but if the resolution is not to low it should not be an issue.